### PR TITLE
Fix apt source on older debian versions

### DIFF
--- a/test/test.bats
+++ b/test/test.bats
@@ -37,7 +37,7 @@ setup() {
   export -f apt-get
 
   # Provide a default /etc/os-release
-  create_osrelease "$JESSIE_OS_RELEASE"
+  create_osrelease "$BOOKWORM_OS_RELEASE"
 }
 
 teardown() {
@@ -239,6 +239,17 @@ create_osrelease() {
   [ ! -f $TMPDIR/etc/apt/sources.list.d/org-repo.list ]
   [ ! -f $TMPDIR/etc/apt/auth.conf.d/org-repo.conf ]
   [ ! -f $TMPDIR/etc/apt/keyrings/org-repo.gpg ]
+}
+
+@test "basic auth is included in deb sources on older debian versions" {
+  setup_deb_mocks
+  create_osrelease "$JESSIE_OS_RELEASE"
+  run with-cloudsmith --deb --keep
+  assert_success
+  list="$(< $TMPDIR/etc/apt/sources.list.d/org-repo.list)"
+  [ -f $TMPDIR/etc/apt/sources.list.d/org-repo.list ]
+  [ ! -f $TMPDIR/etc/apt/auth.conf.d/org-repo.conf ]
+  [[ "$list" =~ "test-user:test-api-key@dl.cloudsmith.io" ]]
 }
 
 @test "pip.conf is set up" {

--- a/with-cloudsmith
+++ b/with-cloudsmith
@@ -329,16 +329,25 @@ function _setup_deb_source {
   mkdir -p "$ROOT/etc/apt/sources.list.d"
   mkdir -p "$ROOT/etc/apt/auth.conf.d"
 
-  cat > "$ROOT/etc/apt/sources.list.d/$CLOUDSMITH_ORG-$CLOUDSMITH_REPO.list" << EOF
+  if [[ $codename =~ ^(jessie|stretch)$ ]]; then
+    # Use basic auth hard-coded into the source file for older Debian versions
+    cat > "$ROOT/etc/apt/sources.list.d/$CLOUDSMITH_ORG-$CLOUDSMITH_REPO.list" << EOF
+deb [signed-by=$keyring] https://$CLOUDSMITH_USER:$CLOUDSMITH_PASSWORD@dl.cloudsmith.io/basic/$CLOUDSMITH_ORG/$CLOUDSMITH_REPO/deb/$id $codename main
+deb-src [signed-by=$keyring] https://$CLOUDSMITH_USER:$CLOUDSMITH_PASSWORD@dl.cloudsmith.io/basic/$CLOUDSMITH_ORG/$CLOUDSMITH_REPO/deb/$id $codename main
+EOF
+  else
+    # Otherwise, provide a valid auth.conf.d file
+    cat > "$ROOT/etc/apt/sources.list.d/$CLOUDSMITH_ORG-$CLOUDSMITH_REPO.list" << EOF
 deb [signed-by=$keyring] https://dl.cloudsmith.io/basic/$CLOUDSMITH_ORG/$CLOUDSMITH_REPO/deb/$id $codename main
 deb-src [signed-by=$keyring] https://dl.cloudsmith.io/basic/$CLOUDSMITH_ORG/$CLOUDSMITH_REPO/deb/$id $codename main
 EOF
 
-  cat > "$ROOT/etc/apt/auth.conf.d/$CLOUDSMITH_ORG-$CLOUDSMITH_REPO.conf" << EOF
+    cat > "$ROOT/etc/apt/auth.conf.d/$CLOUDSMITH_ORG-$CLOUDSMITH_REPO.conf" << EOF
 machine dl.cloudsmith.io
 login $CLOUDSMITH_USER
 password $CLOUDSMITH_PASSWORD
 EOF
+  fi
 }
 
 function setup_deb {


### PR DESCRIPTION
Provide basic auth in apt sources for older versions of debian that do not support /etc/apt/auth.conf.d