### PR TITLE
Fix file path for composer. Add linden composer repo alias.

### DIFF
--- a/test/test.bats
+++ b/test/test.bats
@@ -278,21 +278,21 @@ create_osrelease() {
   export CLOUDSMITH_API_KEY="test-api-key"
   run with-cloudsmith --composer --keep
   assert_success
-  [ -f $TMPDIR$HOME/.config/composer/auth.json ]
+  [ -f $TMPDIR$HOME/.composer/auth.json ]
 }
 
 @test "composer auth.json is cleaned up" {
   export CLOUDSMITH_API_KEY="test-api-key"
   run with-cloudsmith --composer
   assert_success
-  [ ! -f $TMPDIR$HOME/.config/composer/auth.json ]
+  [ ! -f $TMPDIR$HOME/.composer/auth.json ]
 }
 
 @test "existing composer auth.json is restored" {
   export CLOUDSMITH_API_KEY="test-api-key"
-  mkdir -p "$TMPDIR$HOME/.config/composer"
-  echo "old" > $TMPDIR$HOME/.config/composer/auth.json
+  mkdir -p "$TMPDIR$HOME/.composer"
+  echo "old" > $TMPDIR$HOME/.composer/auth.json
   run with-cloudsmith --composer
   assert_success
-  assert_equal "$(<$TMPDIR$HOME/.config/composer/auth.json)" "old"
+  assert_equal "$(<$TMPDIR$HOME/.composer/auth.json)" "old"
 }

--- a/with-cloudsmith
+++ b/with-cloudsmith
@@ -372,7 +372,7 @@ function teardown_deb {
 ################################
 
 function setup_composer {
-  local auth_file="$ROOT$HOME/.config/composer/auth.json"
+  local auth_file="$ROOT$HOME/.composer/auth.json"
   if [ -f "$auth_file" ]; then
     mv "$auth_file" "$auth_file.bak"
   fi
@@ -385,6 +385,10 @@ function setup_composer {
     "dl.cloudsmith.io": {
       "username": "$CLOUDSMITH_USER",
       "password": "$CLOUDSMITH_PASSWORD"
+    },
+    "cloudsmith.secondlife.io": {
+      "username": "$CLOUDSMITH_USER",
+      "password": "$CLOUDSMITH_PASSWORD"
     }
   }
 }
@@ -392,7 +396,7 @@ EOF
 }
 
 function teardown_composer {
-  local auth_file="$ROOT$HOME/.config/composer/auth.json"
+  local auth_file="$ROOT$HOME/.composer/auth.json"
   rm -rf "$auth_file"
   if [ -f "$auth_file.bak" ]; then
     mv "$auth_file.bak" "$auth_file"


### PR DESCRIPTION
I ran into issues trying to add a cloudsmith composer package as a required package. At first, I fixed this by copying the auth.json file into the same directory as my projects composer.json file, which changed the failure, but did not fix the issue. I was seeing an error about logging into 'composer.secondlife.io', which was not what I configured as my repository. I copied the dl.cloudsmith.io into a new object and that worked. I then attempted to edit a global auth file using the instructions here `https://getcomposer.org/doc/articles/authentication-for-private-packages.md#http-basic` and realized that the correct location for a global auth.json was actually ~/.composer/auth.json, not ~/.config/composer/auth.json. Hopefully I can get farther towards actually using a private composer package with these changes.