### PR TITLE
Accept `--` argument to explicitly start the command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Supported registry types:
 
 ## Use
 
-```
-Usage: with-cloudsmith [options] command
+```text
+Usage: with-cloudsmith [options] [--] command
 
   Set up private Cloudsmith registries temporarily.
 

--- a/test/test.bats
+++ b/test/test.bats
@@ -96,6 +96,12 @@ create_osrelease() {
   assert_equal "$status" "127"
 }
 
+@test "runs subcommand separated with --" {
+  run with-cloudsmith -s -- echo "foo"
+  assert_success
+  assert_output "foo"
+}
+
 @test "requires --org" {
   export CLOUDSMITH_ORG=
   run with-cloudsmith

--- a/with-cloudsmith
+++ b/with-cloudsmith
@@ -18,7 +18,7 @@ KEEP=0
 
 function usage {
   cat <<EOF
-Usage: with-cloudsmith [options] command
+Usage: with-cloudsmith [options] [--] command
 
   Set up private Cloudsmith registries temporarily.
 
@@ -80,6 +80,12 @@ while [[ $# -gt 0 ]]; do
     -h|--help)
       usage
       exit 0
+      ;;
+    --)
+      # Consume the `--`...
+      shift
+      # but that's still the end of the options.
+      break
       ;;
     *)
       break


### PR DESCRIPTION
Hiya. When I tried to use `with-cloudsmith` in a build, I naturally included an `--` argument to separate `with-cloudsmith`'s arguments from the command to run in the activated Cloudsmith context:

```dockerfile
RUN --mount=type=secret,id=cloudsmith \
    with-cloudsmith --deb -- \
    apt-get update …
```

I expected this to work but instead the build stopped with an error like:

```text
0.195 /usr/bin/with-cloudsmith: line 436: --: command not found
```

Terminating the argument list with `--` is a common enough convention that users may reasonably expect it.

* In POSIX.1-2017's Utility Conventions, [Utility Syntax Guideline](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02) \#10 suggests `--` “should be accepted as a delimiter indicating the end of options. Any following arguments should be treated as operands, even if they begin with the '`-`' character.”
* [Bash's built-in commands](https://www.gnu.org/software/bash/manual/html_node/Shell-Builtin-Commands.html) also generally “accept[] ‘`--`’ to signify the end of the options”.

This change adds support for `--` to terminate the arguments intended for `with-cloudsmith` and begin the command to run. We need only consume the `--` before we halt argument processing, so that the following arguments can be run as the indicated command, not including the `--`.

This seem OK? Thanks!