### PR TITLE
fix generated composer hostname

### DIFF
--- a/with-cloudsmith
+++ b/with-cloudsmith
@@ -392,7 +392,7 @@ function setup_composer {
       "username": "$CLOUDSMITH_USER",
       "password": "$CLOUDSMITH_PASSWORD"
     },
-    "cloudsmith.secondlife.io": {
+    "composer.secondlife.io": {
       "username": "$CLOUDSMITH_USER",
       "password": "$CLOUDSMITH_PASSWORD"
     }


### PR DESCRIPTION
Dumb mistake on my part in the previous release. 

cloudsmith.secondlife.io -> composer.secondlife.io